### PR TITLE
Cache.get(key, callback) feature

### DIFF
--- a/cache.js
+++ b/cache.js
@@ -29,6 +29,8 @@ window.Cache = {
 				localStorage.removeItem('cache.js' + key);
 				return null;
 			}
+		} else if (Object.prototype.toString.call(arguments[1]) == '[object Function]') {
+			return arguments[1](key);
 		} else {
 			return null;
 		}

--- a/readme.md
+++ b/readme.md
@@ -51,6 +51,24 @@ Pulling it all together, you might do something like this:
       Cache.set("/url", response);
       // Do something awesome with your responseText    
     });
+    
+### Optional 'get' function if value is null
+
+Often, you'll want to do something if the value is not cached. Pass a function to the `get` function:
+
+    var result = Cache.get('empty key', function(key) {
+      return 'bacon';
+    });
+    // `result` is now 'bacon' since there was no stored value.
+
+For example, you could execute an Ajax call if the local storage is empty. Here's the earlier example with a cleaner style:
+
+    return Cache.get("/url", function(key) {
+      return $.get(key, function (response) {
+        Cache.set(key, response);
+        return response;
+      });
+    });
 
 ## Bugs / Contributions
 

--- a/test/cache-spec.js
+++ b/test/cache-spec.js
@@ -45,4 +45,27 @@ describe("Cache", function() {
 		expect(localStorage.getItem("cache.jsfoo")).toBeDefined();
 	});
 
+	it("should call an optional function if value is null", function () {
+		var result = Cache.get('empty with function', function (key) {
+			return 'bacon';
+		});
+		expect(result).toEqual('bacon');
+	});
+
+	it("should not call optional function if value is zero", function () {
+		Cache.set('zero', 0);
+		var result = Cache.get('zero', function (key) {
+			return 1000;
+		});
+		expect(result).toEqual(0);
+	});
+
+	it("should not call optional function if value exists", function () {
+		Cache.set('existing', 'bacon');
+		var result = Cache.get('existing', function (key) {
+			return 'porcupine';
+		});
+		expect(result).toEqual('bacon');
+	});
+
 });


### PR DESCRIPTION
These two commits allow the user to pass a function to `get`. If there is no value for a key, the callback function will be called with the key and its value will be returned.

No extra caching will be done. It is up to the developer to call Cache.set with the new value if desired.

Three specs included (all pass).
